### PR TITLE
release: v3.18 - DSP optimization, touchpad remap, audio haptic, 0xF9 status layout fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,10 +58,7 @@ set(OPUS_INCLUDE_DIRS
 target_include_directories(libopuscodec PRIVATE ${OPUS_INCLUDE_DIRS})
 target_include_directories(app PRIVATE ${OPUS_INCLUDE_DIRS})
 
-# Keep every Opus instruction in SRAM/TCM. Opus is compiled without LTO so the
-# linker can reliably select libopuscodec.a members instead of anonymous LTO
-# partitions. The board's original linker template remains the source of truth;
-# only the archive selector below is injected into its tcm_text output section.
+# Place all Opus code+rodata into SRAM/TCM via linker script injection
 get_property(OPUS_BASE_LINKER_SCRIPT GLOBAL PROPERTY LINKER_SCRIPT_IN)
 if(NOT EXISTS "${OPUS_BASE_LINKER_SCRIPT}")
     message(FATAL_ERROR "Cannot locate the board linker template: ${OPUS_BASE_LINKER_SCRIPT}")

--- a/lib/opus/celt/dump_modes/Makefile
+++ b/lib/opus/celt/dump_modes/Makefile
@@ -1,0 +1,35 @@
+
+CFLAGS=-O2 -Wall -Wextra -DHAVE_CONFIG_H
+INCLUDES=-I. -I../ -I../.. -I../../include
+
+SOURCES = dump_modes.c \
+          ../modes.c \
+          ../cwrs.c \
+          ../rate.c \
+          ../entcode.c \
+          ../entenc.c \
+          ../entdec.c \
+          ../mathops.c \
+          ../mdct.c \
+          ../celt.c \
+          ../kiss_fft.c \
+          ../quant_bands.c \
+          ../laplace.c
+
+ifdef HAVE_ARM_NE10
+CC = gcc
+CFLAGS += -mfpu=neon
+INCLUDES += -I$(NE10_INCDIR) -DHAVE_ARM_NE10 -DOPUS_ARM_PRESUME_NEON_INTR
+LIBS = -L$(NE10_LIBDIR) -lNE10
+SOURCES += ../arm/celt_ne10_fft.c \
+           dump_modes_arm_ne10.c \
+           ../arm/armcpu.c
+endif
+
+all: dump_modes
+
+dump_modes:
+	$(PREFIX)$(CC) $(CFLAGS) $(INCLUDES) -DCUSTOM_MODES_ONLY -DCUSTOM_MODES $(SOURCES) -o $@ $(LIBS) -lm
+
+clean:
+	rm -f dump_modes

--- a/lib/opus/celt/ecintrin.h
+++ b/lib/opus/celt/ecintrin.h
@@ -48,9 +48,7 @@
 /*Count leading zeros.
   This macro should only be used for implementing ec_ilog(), if it is defined.
   All other code should use EC_ILOG() instead.*/
-#if defined(E907_OPUS_DSP)
-/* E907 has a native count-leading-zero instruction. Without this override,
-   GCC lowers __builtin_clz() to the out-of-line libgcc __clzsi2 helper. */
+#if defined(E907_OPUS_DSP) && !defined(E907_DISABLE_FF1)
 static __inline__ unsigned int opus_e907_clz(unsigned int value)
 {
   unsigned int result;

--- a/lib/opus/celt/fixed_generic.h
+++ b/lib/opus/celt/fixed_generic.h
@@ -82,8 +82,6 @@ static OPUS_INLINE opus_val32 e907_mult16_32_q15(opus_val16 a, opus_val32 b)
 static OPUS_INLINE opus_val32 e907_mult32_32_q16(opus_val32 a, opus_val32 b)
 {
     opus_int64 product;
-    /* E907 produces the complete 64-bit product in one instruction. WEXTI,
-       emitted for the shift below, then extracts bits 47:16. */
     __asm__ volatile("mulsr64 %0, %1, %2"
                      : "=r"(product)
                      : "r"(a), "r"(b));
@@ -101,8 +99,6 @@ static OPUS_INLINE opus_val32 e907_mult32_32_q16(opus_val32 a, opus_val32 b)
 static OPUS_INLINE opus_val32 e907_mult32_32_q31(opus_val32 a, opus_val32 b)
 {
     opus_val32 result;
-    /* K.WMMUL is the E907's native signed Q31 multiply. Opus never passes
-       the sole saturating corner case (-1.0 * -1.0) to this primitive. */
     __asm__ volatile("kwmmul %0, %1, %2"
                      : "=r"(result)
                      : "r"(a), "r"(b));

--- a/lib/opus/celt/mathops.c
+++ b/lib/opus/celt/mathops.c
@@ -286,7 +286,7 @@ opus_val32 celt_rcp_norm32(opus_val32 x)
 /** Reciprocal approximation (Q15 input, Q16 output) */
 opus_val32 celt_rcp(opus_val32 x)
 {
-#if defined(E907_OPUS_DSP)
+#if defined(E907_OPUS_DSP) && !defined(E907_DISABLE_DIVU)
    celt_sig_assert(x>0);
    if (x == 1) return 2147483647;
    opus_uint32 result;

--- a/lib/opus_config.h
+++ b/lib/opus_config.h
@@ -10,9 +10,13 @@
 
 #define HAVE_LRINTF        1
 
-/* E907 DSP: use kmmwb2/smmwb/clz32 for hot fixed-point paths */
+/* E907 vendor DSP — ff1 (CLZ) disabled: causes opus_encode hang
+ * (self-test passes but fails under ISR/pipeline pressure).
+ * All other DSP instructions enabled.
+ * TCM placement kept for cache-miss reduction. */
 #if defined(__riscv)
 #define E907_OPUS_DSP      1
+#define E907_DISABLE_FF1   1
 #define OPUS_TCM_CODE      __attribute__((section(".tcm_code")))
 #define OPUS_TCM_CONST     __attribute__((section(".tcm_const")))
 #else

--- a/src/FreeRTOSConfig.h
+++ b/src/FreeRTOSConfig.h
@@ -59,7 +59,7 @@
 #define configUSE_TIMERS                        1
 #define configTIMER_TASK_PRIORITY               (configMAX_PRIORITIES - 1)
 #define configTIMER_QUEUE_LENGTH                4
-#define configTIMER_TASK_STACK_DEPTH            (configMINIMAL_STACK_SIZE)
+#define configTIMER_TASK_STACK_DEPTH            (configMINIMAL_STACK_SIZE * 3)
 
 /* Set the following definitions to 1 to include the API function, or zero
 to exclude the API function. */

--- a/src/audio.c
+++ b/src/audio.c
@@ -7,12 +7,14 @@
 #include "FreeRTOS.h"
 #include "semphr.h"
 #include "queue.h"
+#include "timers.h"
 #include "bflb_mtimer.h"
 
 #include "opus.h"
 #include <string.h>
 #include "debug_log.h"
 #include <math.h>
+
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
@@ -31,40 +33,6 @@
 #define MIC_OPUS_SIZE       71      /* Opus encoded mic frame from DualSense */
 #define MIC_CHANNELS        1       /* Controller sends mono mic */
 #define MIC_QUEUE_DEPTH     4
-
-#if LOG_LEVEL >= 3
-/* Aggregate codec timings so UART logging does not perturb every frame. */
-#define OPUS_TIMING_WINDOW  1280U
-
-typedef struct {
-    uint32_t count;
-    uint32_t total_us;
-    uint32_t min_us;
-    uint32_t max_us;
-} opus_timing_stats_t;
-
-static void opus_timing_record(opus_timing_stats_t *stats,
-                               const char *name, uint32_t elapsed_us)
-{
-    if (stats->count == 0 || elapsed_us < stats->min_us)
-        stats->min_us = elapsed_us;
-    if (elapsed_us > stats->max_us)
-        stats->max_us = elapsed_us;
-
-    stats->total_us += elapsed_us;
-    stats->count++;
-
-    if (stats->count >= OPUS_TIMING_WINDOW) {
-        LOG_DBG("[OPUS] %s avg=%lu us min=%lu us max=%lu us n=%lu\n",
-                name,
-                (unsigned long)(stats->total_us / stats->count),
-                (unsigned long)stats->min_us,
-                (unsigned long)stats->max_us,
-                (unsigned long)stats->count);
-        memset(stats, 0, sizeof(*stats));
-    }
-}
-#endif
 
 /* Polyphase sinc resampler: 512→480 = 16:15 ratio
  * Matches DS5Dongle's WDL sinc resampler for anti-alias filtering.
@@ -87,6 +55,7 @@ static uint8_t  packet_counter;
 static volatile bool plug_headset;
 static volatile bool mic_enabled;   /* host opened mic interface AND config allows */
 static volatile bool mic_status_pending;  /* deferred: send 0x32 to controller */
+static int encoder_force_channels;
 
 static QueueHandle_t mic_queue;
 
@@ -96,7 +65,10 @@ static int16_t  spk_resamp[OPUS_FRAME_SAMPLES * 2];
 static bool     mic_first_frame;
 static volatile bool encoding_in_progress;
 static volatile bool encoder_reset_pending;
-static int encoder_force_channels;
+static volatile bool audio_task_killed;
+static volatile uint64_t encode_start_us;
+static TaskHandle_t audio_task_handle;
+static TimerHandle_t encode_watchdog;
 
 /* Double-frame buffers for 0x39 report (2x haptics + 2x opus per packet) */
 static uint8_t  opus_slots[2][OPUS_OUT_SIZE];
@@ -171,13 +143,9 @@ static void resample_512_480(const int16_t *in, int16_t *out)
         int phase  = (int)(src_pos % RESAMP_PHASES);
 
         const int16_t *c = sinc_q15[phase];
-        int32_t sum_l = (1 << 14);  /* +0.5 LSB rounding bias before >>15 */
+        int32_t sum_l = (1 << 14);
         int32_t sum_r = (1 << 14);
 
-        /* All but six outputs are away from an input edge. Keeping that hot
-           path branch-free avoids 16 clamps and the inner-loop branch for
-           every sample. Input is the original 4-channel USB buffer, so this
-           also removes the temporary stereo de-interleave pass. */
         if (center >= SINC_HALF_TAPS - 1 &&
             center <= HALF_ACCUM - SINC_HALF_TAPS - 1) {
             const int16_t *s = in +
@@ -254,8 +222,58 @@ static void decimate_haptics(const int16_t *in, int8_t *out, uint32_t in_samples
     }
 }
 
+/* ---- Audio-to-Haptic: decimate audio ch0/ch1 waveform to haptic format ----
+ * Same 16:1 point-sample as decimate_haptics, but reads ch0/ch1 instead of
+ * ch2/ch3.  DualSense LRA needs an oscillating waveform, not DC envelope. */
+static void audio_to_haptic(const int16_t *in, int8_t *out, uint32_t in_samples)
+{
+    uint32_t out_pairs = in_samples / HAPTIC_DECIMATE;
+    if (out_pairs > HAPTIC_BUF_SIZE / 2)
+        out_pairs = HAPTIC_BUF_SIZE / 2;
+
+    float gain_f = config_get()->haptics_gain;
+    if (gain_f < 1.0f) gain_f = 1.0f;
+    if (gain_f > 2.0f) gain_f = 2.0f;
+    int32_t gain_fp = (int32_t)(gain_f * 256.0f);
+
+    for (uint32_t i = 0; i < out_pairs; i++) {
+        uint32_t idx = (i * HAPTIC_DECIMATE) * USB_AUDIO_CHANNELS;
+        int32_t val_l = in[idx];       /* ch0 */
+        int32_t val_r = in[idx + 1];   /* ch1 */
+        val_l = (val_l * gain_fp) >> 16;
+        val_r = (val_r * gain_fp) >> 16;
+        if (val_l > 127) val_l = 127;
+        if (val_l < -128) val_l = -128;
+        if (val_r > 127) val_r = 127;
+        if (val_r < -128) val_r = -128;
+        out[i * 2]     = (int8_t)val_l;
+        out[i * 2 + 1] = (int8_t)val_r;
+    }
+}
+
+/* Detect whether ch2/ch3 carry real HD rumble or just noise/dither.
+ * Threshold avoids false positives from OS-injected low-level dither. */
+#define HAPTIC_SILENCE_THRESH  256
+
+static bool haptic_channel_silent(const int16_t *in, uint32_t in_samples)
+{
+    int32_t peak = 0;
+    for (uint32_t i = 0; i < in_samples; i += HAPTIC_DECIMATE) {
+        uint32_t idx = i * USB_AUDIO_CHANNELS;
+        int32_t v2 = in[idx + 2];
+        int32_t v3 = in[idx + 3];
+        if (v2 < 0) v2 = -v2;
+        if (v3 < 0) v3 = -v3;
+        if (v2 > peak) peak = v2;
+        if (v3 > peak) peak = v3;
+    }
+    return peak < HAPTIC_SILENCE_THRESH;
+}
+
 /* ---- Build and send BT report 0x39 (547 bytes, double-frame) ---- */
-static void send_audio_report(void)
+#define AUDIO_SEND_FAIL_MAX  50   /* ~1s @ 21ms/frame → force disconnect */
+
+static int send_audio_report(void)
 {
     static uint8_t pkt[DS5_BT_AUDIO_REPORT_SIZE];
     memset(pkt, 0, sizeof(pkt));
@@ -297,12 +315,61 @@ static void send_audio_report(void)
                              DS5_BT_AUDIO_REPORT_SIZE - 4);
     ds5_write_le32(&pkt[DS5_BT_AUDIO_REPORT_SIZE - 4], crc);
 
+    static uint32_t fail_log_count = 0;
     int ret = bt_hid_host_send_output(pkt, DS5_BT_AUDIO_REPORT_SIZE);
-    if (ret)
-        LOG_ERR("[AUDIO] BT send failed: %d\n", ret);
+    if (ret) {
+        fail_log_count++;
+        if (fail_log_count <= 3 || (fail_log_count % 100) == 0)
+            LOG_ERR("[AUDIO] BT send failed: %d (x%lu)\n",
+                    ret, (unsigned long)fail_log_count);
+    } else {
+        fail_log_count = 0;
+    }
+    return ret;
 }
 
 /* ---- Public API ---- */
+
+#define STACK_WORDS(bytes) \
+    (((bytes) + sizeof(StackType_t) - 1) / sizeof(StackType_t))
+#define AUDIO_TASK_STACK_SIZE STACK_WORDS(1024*32)
+#define AUDIO_TASK_PRIORITY   (configMAX_PRIORITIES - 2)
+
+#define ENCODE_TIMEOUT_US  15000  /* 15ms — normal encode takes ~5-7ms */
+#define WATCHDOG_PERIOD_MS 20
+
+static void encode_watchdog_cb(TimerHandle_t timer)
+{
+    (void)timer;
+    if (!encoding_in_progress) return;
+
+    uint64_t elapsed = bflb_mtimer_get_time_us() - encode_start_us;
+    if (elapsed < ENCODE_TIMEOUT_US) return;
+
+    if (audio_task_handle) {
+        vTaskSuspend(audio_task_handle);
+    }
+
+    encoding_in_progress = false;
+    encoder_reset_pending = true;
+    audio_task_killed = true;
+}
+
+bool audio_check_respawn(void)
+{
+    if (!audio_task_killed) return false;
+    audio_task_killed = false;
+
+    if (audio_task_handle) {
+        vTaskDelete(audio_task_handle);
+        audio_task_handle = NULL;
+    }
+
+    xTaskCreate(audio_task, "audio", AUDIO_TASK_STACK_SIZE,
+                NULL, AUDIO_TASK_PRIORITY, NULL);
+    LOG_ERR("[WD-OPUS] respawned\n");
+    return true;
+}
 
 int audio_init(void)
 {
@@ -336,12 +403,7 @@ int audio_init(void)
     opus_encoder_ctl(encoder, OPUS_SET_BITRATE(200 * 8 * 100));
     opus_encoder_ctl(encoder, OPUS_SET_VBR(0));
     opus_encoder_ctl(encoder, OPUS_SET_COMPLEXITY(0));
-    err = opus_encoder_ctl(encoder, OPUS_SET_FORCE_CHANNELS(1));
-    if (err != OPUS_OK) {
-        LOG_ERR("[AUDIO] Opus force mono failed: %d\n", err);
-        encoder = NULL;
-        return -1;
-    }
+    opus_encoder_ctl(encoder, OPUS_SET_FORCE_CHANNELS(1));
     encoder_force_channels = 1;
 
     decoder = (OpusDecoder *)decoder_mem;
@@ -369,9 +431,14 @@ int audio_init(void)
     memset(opus_slots, 0, sizeof(opus_slots));
     memset(haptic_slots, 0, sizeof(haptic_slots));
 
-    LOG_INF("[AUDIO] Opus static init (enc=%d/%d dec=%d/%d mic_q=%p)\n",
+    encode_watchdog = xTimerCreate("wd-opus", pdMS_TO_TICKS(WATCHDOG_PERIOD_MS),
+                                   pdTRUE, NULL, encode_watchdog_cb);
+    if (encode_watchdog)
+        xTimerStart(encode_watchdog, 0);
+
+    LOG_INF("[AUDIO] Opus static init (enc=%d/%d dec=%d/%d mic_q=%p wd=%p)\n",
            enc_size, OPUS_ENC_MAX_SIZE, dec_size, OPUS_DEC_MAX_SIZE,
-           (void *)mic_queue);
+           (void *)mic_queue, (void *)encode_watchdog);
     return 0;
 }
 
@@ -405,24 +472,30 @@ void audio_task(void *arg)
 {
     (void)arg;
 
+    audio_task_handle = xTaskGetCurrentTaskHandle();
+
+    if (encoder_reset_pending) {
+        encoder_reset_pending = false;
+        opus_encoder_ctl(encoder, OPUS_RESET_STATE);
+        LOG_ERR("[WD-OPUS] encoder reset\n");
+    }
+
     SemaphoreHandle_t sem = (SemaphoreHandle_t)usb_audio_get_semaphore();
-#if LOG_LEVEL >= 3
-    opus_timing_stats_t encode_timing = {0};
-#endif
     LOG_INF("[AUDIO] Task started\n");
+
+    uint32_t send_fail_streak = 0;
 
     for (;;) {
         if (xSemaphoreTake(sem, pdMS_TO_TICKS(25)) == pdTRUE) {
-            if (usb_audio_is_active() &&
-                usb_audio_read(pcm_block) &&
-                bt_hid_host_get_state() == BT_HID_STATE_CONNECTED)
+            bool a_active = usb_audio_is_active();
+            bool a_read   = a_active ? usb_audio_read(pcm_block) : false;
+            bool a_bt     = bt_hid_host_get_state() == BT_HID_STATE_CONNECTED;
+
+            if (a_active && a_read && a_bt)
             {
                 bool speaker_on = !config_get()->disable_speaker;
                 int target_channels = plug_headset ? 2 : 1;
 
-                /* Opus supports changing the encoded channel count between
-                 * frames. Keep the CTL in the owning audio task so headset
-                 * reports cannot race an active opus_encode() call. */
                 if (target_channels != encoder_force_channels) {
                     int ctl_err = opus_encoder_ctl(
                         encoder, OPUS_SET_FORCE_CHANNELS(target_channels));
@@ -435,31 +508,29 @@ void audio_task(void *arg)
                     }
                 }
 
-                for (int slot = 0; slot < 2; slot++) {
-                    if (slot == 1)
-                        taskYIELD();
+                uint8_t ah_mode = config_get()->audio_haptic;
 
+                for (int slot = 0; slot < 2; slot++) {
                     const uint32_t base = (uint32_t)slot * HALF_ACCUM;
                     const int16_t *slot_pcm =
                         &pcm_block[base * USB_AUDIO_CHANNELS];
 
-                    decimate_haptics(slot_pcm, haptic_slots[slot], HALF_ACCUM);
+                    if (ah_mode == 2) {
+                        audio_to_haptic(slot_pcm, haptic_slots[slot], HALF_ACCUM);
+                    } else if (ah_mode == 1 &&
+                               haptic_channel_silent(slot_pcm, HALF_ACCUM)) {
+                        audio_to_haptic(slot_pcm, haptic_slots[slot], HALF_ACCUM);
+                    } else {
+                        decimate_haptics(slot_pcm, haptic_slots[slot], HALF_ACCUM);
+                    }
 
                     if (speaker_on) {
                         resample_512_480(slot_pcm, spk_resamp);
+                        encode_start_us = bflb_mtimer_get_time_us();
                         encoding_in_progress = true;
-#if LOG_LEVEL >= 3
-                        uint64_t encode_start_us = bflb_mtimer_get_time_us();
-#endif
                         int encoded = opus_encode(encoder, spk_resamp, OPUS_FRAME_SAMPLES,
                                                   opus_slots[slot], OPUS_OUT_SIZE);
                         encoding_in_progress = false;
-#if LOG_LEVEL >= 3
-                        uint32_t encode_elapsed_us = (uint32_t)
-                            (bflb_mtimer_get_time_us() - encode_start_us);
-                        opus_timing_record(&encode_timing, "enc",
-                                           encode_elapsed_us);
-#endif
 
                         if (encoder_reset_pending) {
                             encoder_reset_pending = false;
@@ -477,7 +548,22 @@ void audio_task(void *arg)
                     }
                 }
 
-                send_audio_report();
+                if (send_audio_report() != 0) {
+                    send_fail_streak++;
+                    if (send_fail_streak >= AUDIO_SEND_FAIL_MAX) {
+                        LOG_ERR("[AUDIO] %u consecutive send failures, "
+                                "forcing disconnect\n",
+                                (unsigned)send_fail_streak);
+                        send_fail_streak = 0;
+                        bt_hid_host_disconnect();
+                    } else if (send_fail_streak > 3) {
+                        vTaskDelay(pdMS_TO_TICKS(20));
+                    } else {
+                        vTaskDelay(1);
+                    }
+                } else {
+                    send_fail_streak = 0;
+                }
             }
         }
 
@@ -565,9 +651,6 @@ void audio_mic_task(void *arg)
     static uint8_t  mic_opus_buf[MIC_OPUS_SIZE];
     static int16_t  mic_mono[OPUS_FRAME_SAMPLES];
     static int16_t  mic_stereo[OPUS_FRAME_SAMPLES * 2];
-#if LOG_LEVEL >= 3
-    opus_timing_stats_t decode_timing = {0};
-#endif
 
     for (;;) {
         if (!mic_queue) {
@@ -581,16 +664,8 @@ void audio_mic_task(void *arg)
         if (!decoder || !mic_enabled)
             continue;
 
-#if LOG_LEVEL >= 3
-        uint64_t decode_start_us = bflb_mtimer_get_time_us();
-#endif
         int decoded = opus_decode(decoder, mic_opus_buf, MIC_OPUS_SIZE,
                                   mic_mono, OPUS_FRAME_SAMPLES, 0);
-#if LOG_LEVEL >= 3
-        uint32_t decode_elapsed_us = (uint32_t)
-            (bflb_mtimer_get_time_us() - decode_start_us);
-        opus_timing_record(&decode_timing, "dec", decode_elapsed_us);
-#endif
         if (decoded <= 0) {
             LOG_ERR("[MIC] Opus decode error: %d\n", decoded);
             continue;

--- a/src/audio.h
+++ b/src/audio.h
@@ -61,4 +61,10 @@ bool audio_mic_active(void);
  */
 void audio_mic_task(void *arg);
 
+/**
+ * Check if the audio task was killed by the encode watchdog and respawn it.
+ * Call periodically from bt_task or main loop. Returns true if respawned.
+ */
+bool audio_check_respawn(void);
+
 #endif /* AUDIO_H */

--- a/src/config.c
+++ b/src/config.c
@@ -66,6 +66,14 @@ void config_validate(void)
         b->led_g = 0xFF;
         b->led_b = 0xFF;
     }
+    if (b->tp_mode > 4)
+        b->tp_mode = 0;
+    if (b->tp_mode_enabled_mask == 0 || b->tp_mode_enabled_mask > 0x1F)
+        b->tp_mode_enabled_mask = 0x01; /* at least mode 0 enabled */
+    if (b->tp_mouse_sensitivity == 0 || b->tp_mouse_sensitivity > 32)
+        b->tp_mouse_sensitivity = 8;
+    if (b->audio_haptic > 2)
+        b->audio_haptic = 0;
 }
 
 void config_load(void)
@@ -93,11 +101,22 @@ void config_load(void)
         cfg.led_r             = 0xFF;
         cfg.led_g             = 0xFF;
         cfg.led_b             = 0xFF;
+        cfg.tp_mode           = 0;     /* off */
+        cfg.tp_mode_enabled_mask = 0x03; /* mode 0 + mode 1 enabled */
+        cfg.tp_mouse_sensitivity = 8;
+    }
+    /* Migrate old 27-byte config: byte 26 was tp_mouse_sensitivity, not mask */
+    if (err == 0 && rlen == 27) {
+        cfg.tp_mouse_sensitivity = cfg.tp_mode_enabled_mask;
+        cfg.tp_mode_enabled_mask = 0x03;
     }
     config_validate();
     LOG_INF("[CFG] Loaded: wake=%d led_off=%d inactive=%dmin poll=%d ps=%d\n",
            cfg.enable_wake, cfg.disable_led, cfg.inactive_time,
            cfg.polling_rate_mode, cfg.ps_shortcut_enabled);
+    LOG_INF("[CFG] tp_mode=%u mask=0x%02x sens=%u (rlen=%u)\n",
+           cfg.tp_mode, cfg.tp_mode_enabled_mask, cfg.tp_mouse_sensitivity,
+           (unsigned)rlen);
 }
 
 bool config_save(void)

--- a/src/config.h
+++ b/src/config.h
@@ -32,6 +32,10 @@ struct __attribute__((packed)) config_body {
     uint8_t led_r;                /* [0-255] custom LED red   (0xFF = default white) */
     uint8_t led_g;                /* [0-255] custom LED green (0xFF = default white) */
     uint8_t led_b;                /* [0-255] custom LED blue  (0xFF = default white) */
+    uint8_t tp_mode;              /* 0=off, 1=dpad, 2=Lmouse+Rdpad, 3=Ldpad+Rmouse, 4=split */
+    uint8_t tp_mode_enabled_mask; /* bitmask of enabled modes (bit0-bit4) */
+    uint8_t tp_mouse_sensitivity; /* [1-32], default 8 */
+    uint8_t audio_haptic;         /* 0=off, 1=auto(game priority), 2=force */
 };
 
 #define CONFIG_VERSION  2

--- a/src/ds5_usb_audio.c
+++ b/src/ds5_usb_audio.c
@@ -225,8 +225,9 @@ static void audio_ep_out_handler(uint8_t busid, uint8_t ep, uint32_t nbytes)
     (void)ep;
 
     if (nbytes == 0 || !stream_active) {
-        if (stream_active)
+        if (stream_active) {
             usbd_ep_start_read(busid, USB_AUDIO_EP_OUT, iso_rx_buf, sizeof(iso_rx_buf));
+        }
         return;
     }
 
@@ -307,7 +308,9 @@ void usbd_audio_open(uint8_t busid, uint8_t intf)
         pcm_write_idx = 0;
         pcm_ready = false;
         state_mgr_set_spk_active(true);
-        usbd_ep_start_read(busid, USB_AUDIO_EP_OUT, iso_rx_buf, sizeof(iso_rx_buf));
+        int r = usbd_ep_start_read(busid, USB_AUDIO_EP_OUT, iso_rx_buf, sizeof(iso_rx_buf));
+        if (r < 0)
+            LOG_ERR("[AUDIO] initial ep_start_read fail=%d\n", r);
     } else if (intf == USB_AUDIO_INTF_MIC) {
         LOG_INF("[AUDIO] Mic stream opened\n");
         mic_active = true;
@@ -418,6 +421,8 @@ bool usb_audio_is_active(void)
 
 void usb_audio_stop(void)
 {
+    if (stream_active)
+        LOG_INF("[AUDIO] usb_audio_stop\n");
     stream_active = false;
     pcm_write_pos = 0;
     pcm_write_idx = 0;
@@ -461,7 +466,6 @@ bool usb_audio_mic_is_active(void)
 {
     return mic_active;
 }
-
 
 void usb_audio_mic_stop(void)
 {

--- a/src/main.c
+++ b/src/main.c
@@ -31,12 +31,11 @@
     (((bytes) + sizeof(StackType_t) - 1) / sizeof(StackType_t))
 
 #define BT_TASK_STACK_SIZE    STACK_WORDS(1024*24)
-#define BT_TASK_PRIORITY      (configMAX_PRIORITIES - 2)
+#define BT_TASK_PRIORITY      (configMAX_PRIORITIES - 3)
 #define USB_TASK_STACK_SIZE   STACK_WORDS(1024*12)
 #define USB_TASK_PRIORITY     (configMAX_PRIORITIES - 1)
-// 设置CONFIG_BT_RX_PRIO=5, 音频任务优先级低于5, 提高回报率
 #define AUDIO_TASK_STACK_SIZE STACK_WORDS(1024*32)
-#define AUDIO_TASK_PRIORITY   (configMAX_PRIORITIES - 3)
+#define AUDIO_TASK_PRIORITY   (configMAX_PRIORITIES - 2)
 #define MIC_TASK_STACK_SIZE   STACK_WORDS(1024*12)
 #define MIC_TASK_PRIORITY     (configMAX_PRIORITIES - 4)
 #define LED_TASK_STACK_SIZE   STACK_WORDS(1024*2)
@@ -56,7 +55,6 @@ static QueueHandle_t output_queue;
 static volatile bool ds5_connected = false;
 static volatile bool ever_connected = false;
 static volatile bool battery_low = false;
-static volatile bool battery_warn = false;
 static volatile bool bt_init_done = false;
 
 static volatile uint8_t cached_battery_level = 0xFF;
@@ -368,7 +366,7 @@ static void on_hid_state(enum bt_hid_host_state state)
         first_input_logged = false;
         usb_wake_on_bt_disconnect();
         if (was_connected && !bt_hid_host_is_switching() &&
-            !config_wake_enabled() && !usb_wake_host_suspended()) {
+            !usb_wake_host_suspended()) {
             usb_deferred_disc_us = bflb_mtimer_get_time_us();
             LOG_INF("[MAIN] USB disconnect deferred (10s timer started)\n");
         }
@@ -443,11 +441,12 @@ static void on_hid_state(enum bt_hid_host_state state)
             if (usb_deferred_disc_us) {
                 usb_deferred_disc_us = 0;
                 LOG_INF("[MAIN] Deferred disconnect cancelled — USB stayed connected\n");
+                send_led_primer();
             } else {
                 usb_soft_connect();
                 LOG_INF("[MAIN] USB replug (was disconnected)\n");
+                stealth_primer_countdown = 5;
             }
-            stealth_primer_countdown = 5;
         } else if (config_usb_stealth()) {
             /* First connection, stealth: USB was disconnected at boot.
              * Let Windows send blue init, then override with our primer. */
@@ -463,7 +462,6 @@ static void on_hid_state(enum bt_hid_host_state state)
         ds5_connected = true;
         ever_connected = true;
         battery_low = false;
-        battery_warn = false;
         primer_resend_us = bflb_mtimer_get_time_us();
         usb_wake_on_bt_connect();
         conn_led_start_us = bflb_mtimer_get_time_us();
@@ -611,6 +609,8 @@ static void bt_task(void *arg)
     conn_led_start_us = bflb_mtimer_get_time_us();
 
     for (;;) {
+        audio_check_respawn();
+
         loop_count++;
         if ((loop_count % 50) == 1) {
             LOG_DBG("[BT_TASK] loop #%u state=%d conn=%d\n",
@@ -810,8 +810,6 @@ static void bt_task(void *arg)
                 if (ds5_connected) {
                     if (battery_low)
                         led_status_set(LED_BLINK_BATTERY);
-                    else if (battery_warn)
-                        led_status_set(LED_BLINK_BATTERY_WARN);
                     else
                         led_status_set(LED_GREEN_SOLID);
                     LOG_DBG("[LED-DBG] toggle OFF: restored green, conn=1\n");
@@ -874,8 +872,8 @@ static void bt_task(void *arg)
                     bt_hid_host_send_output(bt_out, DS5_BT_OUTPUT_REPORT_SIZE);
                     batch++;
                 }
-                vTaskDelay(pdMS_TO_TICKS(16));
-            } else if (xQueueReceive(output_queue, usb_out, pdMS_TO_TICKS(16)) == pdTRUE) {
+                vTaskDelay(pdMS_TO_TICKS(24));
+            } else if (xQueueReceive(output_queue, usb_out, pdMS_TO_TICKS(24)) == pdTRUE) {
                 uint8_t *payload = usb_out + 1;
 
                 /* Stealth mode: drain Windows' blue init frames without forwarding
@@ -1066,6 +1064,9 @@ static void usb_task(void *arg)
     /* Remap profile switch: Create + D-pad Left/Right */
     bool     remap_combo_fired = false;
 
+    /* Touchpad mode cycle: Create + Touchpad Press */
+    bool     tp_mode_combo_fired = false;
+
     /* Volume combo: Options + D-pad Up/Down → Consumer Control Volume */
     bool     vol_key_active = false;
     uint64_t vol_repeat_us  = 0;
@@ -1152,8 +1153,66 @@ static void usb_task(void *arg)
                 }
             }
 
+            /* Remap profile switch: Create + D-pad Left → profile 0, Right → profile 1 */
+            {
+                bool create_held = (raw_report[2 + DS5_BTN_BYTE] & DS5_BTN_CREATE_BIT) != 0;
+                uint8_t dpad = raw_report[2 + DS5_DPAD_BYTE] & DS5_DPAD_MASK;
+
+                if (create_held && !remap_combo_fired) {
+                    int target = -1;
+                    if (dpad == DS5_DPAD_W)
+                        target = 0;
+                    else if (dpad == DS5_DPAD_E)
+                        target = 1;
+
+                    if (target >= 0 && target != remap_get_active_profile()) {
+                        remap_switch_profile((uint8_t)target);
+                        led_status_set(target == 0 ? LED_BLINK_ONCE : LED_BLINK_DOUBLE);
+                        LOG_INF("[REMAP] Combo → profile %d\n", target);
+                        remap_combo_fired = true;
+                    }
+                }
+                if (!create_held)
+                    remap_combo_fired = false;
+            }
+
+            /* Touchpad mode cycle: Create + Touchpad Press */
+            {
+                bool create_held = (raw_report[2 + DS5_BTN_BYTE] & DS5_BTN_CREATE_BIT) != 0;
+                bool tp_pressed  = (raw_report[2 + 9] & 0x02) != 0;
+
+                static uint8_t tp_dbg_cnt = 0;
+                if (create_held && tp_pressed && tp_dbg_cnt < 5) {
+                    LOG_INF("[TP-DBG] Create+TP detected, fired=%d mode=%u mask=0x%02x\n",
+                            tp_mode_combo_fired, config_get()->tp_mode,
+                            config_get()->tp_mode_enabled_mask);
+                    tp_dbg_cnt++;
+                }
+
+                if (create_held && tp_pressed && !tp_mode_combo_fired) {
+                    remap_tp_cycle_mode();
+                    uint8_t new_mode = config_get()->tp_mode;
+                    static const uint8_t mode_blinks[] = {
+                        LED_BLINK_ONCE, LED_BLINK_DOUBLE, LED_BLINK_TRIPLE,
+                        LED_BLINK_TRIPLE, LED_BLINK_TRIPLE
+                    };
+                    led_status_set(mode_blinks[new_mode]);
+                    LOG_INF("[TP] Combo → mode %u\n", new_mode);
+                    tp_mode_combo_fired = true;
+                }
+                if (!create_held || !tp_pressed)
+                    tp_mode_combo_fired = false;
+
+                /* Suppress Create+TP from reaching game */
+                if (create_held && tp_pressed) {
+                    raw_report[2 + DS5_BTN_BYTE] &= ~DS5_BTN_CREATE_BIT;
+                    raw_report[2 + 9] &= ~0x02;
+                }
+            }
+
             if (!vol_key_active)
                 remap_kbd_tick(raw_report + 2);
+            remap_mouse_tick(raw_report + 2);
             remap_apply(raw_report + 2);
             usb_gamepad_send_raw_input(raw_report + 2);
             usb_wake_on_bt_input(raw_report + 2, DS5_USB_INPUT_PAYLOAD_LEN);
@@ -1185,7 +1244,7 @@ static void usb_task(void *arg)
                     inactive_disconnected = false;
                 }
 
-                /* Battery monitoring: <=10% red blink, <=20% yellow blink */
+                /* Battery monitoring: <=10% red blink */
                 uint8_t batt = raw_report[2 + DS5_BATT_BYTE_OFFSET];
                 uint8_t pct  = batt & DS5_BATT_LEVEL_MASK;
                 uint8_t st   = (batt >> DS5_BATT_STATE_SHIFT) & 0x0F;
@@ -1193,21 +1252,13 @@ static void usb_task(void *arg)
                 cached_battery_state = st;
                 bool discharging = (st == DS5_BATT_STATE_DISCHARGE);
                 bool is_low  = discharging && (pct <= DS5_BATT_LOW_THRESHOLD);
-                bool is_warn = discharging && !is_low &&
-                               (pct <= DS5_BATT_WARN_THRESHOLD);
 
                 if (is_low && !battery_low) {
                     battery_low = true;
-                    battery_warn = false;
                     led_status_set(LED_BLINK_BATTERY);
                     LOG_WRN("[MAIN] Battery critical (%d%%)\n", pct * 10);
-                } else if (is_warn && !battery_warn && !battery_low) {
-                    battery_warn = true;
-                    led_status_set(LED_BLINK_BATTERY_WARN);
-                    LOG_WRN("[MAIN] Battery warning (%d%%)\n", pct * 10);
-                } else if (!is_low && !is_warn && (battery_low || battery_warn)) {
+                } else if (!is_low && battery_low) {
                     battery_low = false;
-                    battery_warn = false;
                     if (config_led_disabled() && conn_led_off)
                         led_status_set(LED_OFF);
                     else
@@ -1224,29 +1275,6 @@ static void usb_task(void *arg)
                         bt_hid_host_disconnect();
                         inactive_disconnected = true;
                     }
-                }
-
-                /* Remap profile switch: Create + D-pad Left → profile 0, Right → profile 1 */
-                {
-                    bool create_held = (raw_report[2 + DS5_BTN_BYTE] & DS5_BTN_CREATE_BIT) != 0;
-                    uint8_t dpad = raw_report[2 + DS5_DPAD_BYTE] & DS5_DPAD_MASK;
-
-                    if (create_held && !remap_combo_fired) {
-                        int target = -1;
-                        if (dpad == DS5_DPAD_W)
-                            target = 0;
-                        else if (dpad == DS5_DPAD_E)
-                            target = 1;
-
-                        if (target >= 0 && target != remap_get_active_profile()) {
-                            remap_switch_profile((uint8_t)target);
-                            led_status_set(target == 0 ? LED_BLINK_ONCE : LED_BLINK_DOUBLE);
-                            LOG_INF("[REMAP] Combo → profile %d\n", target);
-                            remap_combo_fired = true;
-                        }
-                    }
-                    if (!create_held)
-                        remap_combo_fired = false;
                 }
 
                 /* PS key scheduled send + release (runs unconditionally) */
@@ -1413,7 +1441,7 @@ int main(void)
                 NULL, USB_TASK_PRIORITY, NULL);
     if (audio_ok) {
         xTaskCreate(audio_task, "audio", AUDIO_TASK_STACK_SIZE,
-                    NULL, AUDIO_TASK_PRIORITY, NULL);
+                    NULL, AUDIO_TASK_PRIORITY, NULL);  /* handle stored in audio_task() */
         xTaskCreate(audio_mic_task, "mic", MIC_TASK_STACK_SIZE,
                     NULL, MIC_TASK_PRIORITY, NULL);
     }

--- a/src/remap.c
+++ b/src/remap.c
@@ -2,6 +2,8 @@
 #include "usb_gamepad.h"
 #include "debug_log.h"
 #include "easyflash.h"
+#include "config.h"
+#include "bflb_mtimer.h"
 #include <string.h>
 #include <stdbool.h>
 
@@ -12,7 +14,7 @@
 /* p[9]:  PS[0] TP_click[1] Mute[2]                                   */
 /* ------------------------------------------------------------------ */
 
-static const struct { uint8_t off; uint8_t mask; } BTN_LOC[REMAP_BTN_COUNT] = {
+static const struct { uint8_t off; uint8_t mask; } BTN_LOC[REMAP_LEGACY_BTN_COUNT] = {
     [REMAP_BTN_SQUARE]   = { 7, 0x10 },
     [REMAP_BTN_CROSS]    = { 7, 0x20 },
     [REMAP_BTN_CIRCLE]   = { 7, 0x40 },
@@ -30,6 +32,13 @@ static const struct { uint8_t off; uint8_t mask; } BTN_LOC[REMAP_BTN_COUNT] = {
     [REMAP_BTN_MUTE]     = { 9, 0x04 },
 };
 
+/* Touchpad split-zone parameters */
+#define TP_SPLIT_X      960
+#define TP_L_CENTER_X   480
+#define TP_R_CENTER_X   1440
+#define TP_CENTER_Y     540
+#define TP_DEADZONE     120
+
 /* ------------------------------------------------------------------ */
 /* Module state                                                         */
 /* ------------------------------------------------------------------ */
@@ -38,6 +47,14 @@ static remap_entry_t g_profiles[REMAP_PROFILE_COUNT][REMAP_BTN_COUNT];
 static uint8_t active_profile = 0;
 static bool g_remap_is_identity = true;
 static uint8_t last_kbd_report[8];
+
+/* Mouse mode state */
+static int16_t  tp_mouse_last_x = -1;
+static int16_t  tp_mouse_last_y = -1;
+static uint32_t tp_click_down_ms = 0;
+static bool     tp_click_held = false;
+static bool     tp_right_triggered = false;
+static uint8_t  last_mouse_buttons = 0;
 
 static const char *profile_keys[REMAP_PROFILE_COUNT] = {
     "btn_remap",      /* profile 0 — backward compatible key */
@@ -48,18 +65,22 @@ static const char *profile_keys[REMAP_PROFILE_COUNT] = {
 /* Internal helpers                                                     */
 /* ------------------------------------------------------------------ */
 
-static bool validate_entry(const remap_entry_t *e)
+static bool validate_entry(const remap_entry_t *e, uint8_t src_id)
 {
-    if (e->type == REMAP_TYPE_BTN)
+    if (e->type == REMAP_TYPE_BTN) {
         return e->value < REMAP_BTN_COUNT;
+    }
     if (e->type == REMAP_TYPE_KBD)
         return e->value > 0 && e->value <= 0x73;
+    if (e->type == REMAP_TYPE_MOUSE)
+        return e->value <= 2; /* 0=left, 1=right, 2=middle */
     return false;
 }
 
+
 static void sanitize_entry(remap_entry_t *e, uint8_t src_id)
 {
-    if (!validate_entry(e))
+    if (!validate_entry(e, src_id))
         *e = (remap_entry_t){ REMAP_TYPE_BTN, src_id, 0, 0 };
 }
 
@@ -88,8 +109,94 @@ static void update_identity_cache(void)
 
 static inline uint8_t get_src_bit(const uint8_t *p, int id)
 {
-    return (p[BTN_LOC[id].off] & BTN_LOC[id].mask) ? 1u : 0u;
+    if (id < REMAP_LEGACY_BTN_COUNT)
+        return (p[BTN_LOC[id].off] & BTN_LOC[id].mask) ? 1u : 0u;
+
+    if (id >= REMAP_BTN_DPAD_UP && id <= REMAP_BTN_DPAD_RIGHT) {
+        uint8_t hat = p[7] & 0x0F;
+        switch (id) {
+        case REMAP_BTN_DPAD_UP:    return (hat == 0 || hat == 1 || hat == 7) ? 1u : 0u;
+        case REMAP_BTN_DPAD_DOWN:  return (hat == 3 || hat == 4 || hat == 5) ? 1u : 0u;
+        case REMAP_BTN_DPAD_LEFT:  return (hat == 5 || hat == 6 || hat == 7) ? 1u : 0u;
+        case REMAP_BTN_DPAD_RIGHT: return (hat == 1 || hat == 2 || hat == 3) ? 1u : 0u;
+        }
+    }
+
+    if (id >= REMAP_BTN_TP_L_TOUCH && id <= REMAP_BTN_TP_R_CLICK) {
+        uint8_t mode = config_get()->tp_mode;
+
+        /* mode 0 (off): all zone buttons suppressed */
+        if (mode == 0) return 0u;
+
+        /* Determine which button groups are active and their centers */
+        bool left_active  = (mode == 1 || mode == 3 || mode == 4);
+        bool right_active = (mode == 1 || mode == 2 || mode == 4);
+
+        /* Suppress inactive groups */
+        if (!left_active && id >= REMAP_BTN_TP_L_TOUCH && id <= REMAP_BTN_TP_L_CLICK)
+            return 0u;
+        if (!right_active && id >= REMAP_BTN_TP_R_TOUCH && id <= REMAP_BTN_TP_R_CLICK)
+            return 0u;
+
+        const uint8_t *tp = &p[32];
+        if (tp[0] & 0x80) return 0u; /* finger 0 not active */
+        int16_t x = tp[1] | ((tp[2] & 0x0F) << 8);
+        int16_t y = ((tp[2] & 0xF0) >> 4) | (tp[3] << 4);
+
+        /* Center point depends on mode */
+        int16_t cx_l, cx_r;
+        if (mode == 1) {
+            cx_l = 960; cx_r = 960; /* whole-pad center */
+        } else {
+            cx_l = TP_L_CENTER_X; cx_r = TP_R_CENTER_X;
+        }
+
+        /* In split modes (2/3/4), restrict to the correct half */
+        bool left_half = (x < TP_SPLIT_X);
+        bool need_half_check = (mode != 1);
+
+        /* Left-half sources (19-24) */
+        if (id >= REMAP_BTN_TP_L_TOUCH && id <= REMAP_BTN_TP_L_CLICK) {
+            if (need_half_check && !left_half) return 0u;
+            if (id == REMAP_BTN_TP_L_TOUCH) return 1u;
+            if (id == REMAP_BTN_TP_L_CLICK)
+                return (p[9] & 0x02) ? 1u : 0u;
+            int16_t dx = x - cx_l;
+            int16_t dy = y - TP_CENTER_Y;
+            int16_t adx = dx < 0 ? -dx : dx;
+            int16_t ady = dy < 0 ? -dy : dy;
+            if (adx < TP_DEADZONE && ady < TP_DEADZONE) return 0u;
+            switch (id) {
+            case REMAP_BTN_TP_L_UP:    return (ady >= adx && dy < 0) ? 1u : 0u;
+            case REMAP_BTN_TP_L_DOWN:  return (ady >= adx && dy > 0) ? 1u : 0u;
+            case REMAP_BTN_TP_L_LEFT:  return (adx > ady  && dx < 0) ? 1u : 0u;
+            case REMAP_BTN_TP_L_RIGHT: return (adx > ady  && dx > 0) ? 1u : 0u;
+            }
+        }
+
+        /* Right-half sources (25-30) */
+        if (id >= REMAP_BTN_TP_R_TOUCH && id <= REMAP_BTN_TP_R_CLICK) {
+            if (need_half_check && left_half) return 0u;
+            if (id == REMAP_BTN_TP_R_TOUCH) return 1u;
+            if (id == REMAP_BTN_TP_R_CLICK)
+                return (p[9] & 0x02) ? 1u : 0u;
+            int16_t dx = x - cx_r;
+            int16_t dy = y - TP_CENTER_Y;
+            int16_t adx = dx < 0 ? -dx : dx;
+            int16_t ady = dy < 0 ? -dy : dy;
+            if (adx < TP_DEADZONE && ady < TP_DEADZONE) return 0u;
+            switch (id) {
+            case REMAP_BTN_TP_R_UP:    return (ady >= adx && dy < 0) ? 1u : 0u;
+            case REMAP_BTN_TP_R_DOWN:  return (ady >= adx && dy > 0) ? 1u : 0u;
+            case REMAP_BTN_TP_R_LEFT:  return (adx > ady  && dx < 0) ? 1u : 0u;
+            case REMAP_BTN_TP_R_RIGHT: return (adx > ady  && dx > 0) ? 1u : 0u;
+            }
+        }
+    }
+    return 0u;
 }
+
+#define REMAP_MIN_SET_SIZE (REMAP_OLD_BTN_COUNT * sizeof(remap_entry_t))
 
 static void load_single_profile(uint8_t idx)
 {
@@ -99,8 +206,15 @@ static void load_single_profile(uint8_t idx)
     size_t n_loaded = len / sizeof(remap_entry_t);
     for (size_t i = 0; i < n_loaded; i++)
         sanitize_entry(&g_profiles[idx][i], (uint8_t)i);
-    for (size_t i = n_loaded; i < REMAP_BTN_COUNT; i++)
-        g_profiles[idx][i] = (remap_entry_t){ REMAP_TYPE_BTN, (uint8_t)i, 0, 0 };
+    /* Old format (23 entries): indices 19-22 had different meaning (TP_UP/DOWN/LEFT/RIGHT).
+     * Reset them to identity since the touchpad model has changed. */
+    if (n_loaded > 0 && n_loaded <= REMAP_OLD_BTN_COUNT) {
+        for (size_t i = REMAP_BTN_TP_L_TOUCH; i < REMAP_BTN_COUNT; i++)
+            g_profiles[idx][i] = (remap_entry_t){ REMAP_TYPE_BTN, (uint8_t)i, 0, 0 };
+    } else {
+        for (size_t i = n_loaded; i < REMAP_BTN_COUNT; i++)
+            g_profiles[idx][i] = (remap_entry_t){ REMAP_TYPE_BTN, (uint8_t)i, 0, 0 };
+    }
 }
 
 /* ------------------------------------------------------------------ */
@@ -155,9 +269,17 @@ void remap_set(const uint8_t *data, uint8_t len)
 void remap_set_profile(uint8_t profile, const uint8_t *data, uint8_t len)
 {
     if (profile >= REMAP_PROFILE_COUNT) return;
-    if (len < REMAP_BTN_COUNT * sizeof(remap_entry_t)) return;
+    size_t n_entries = len / sizeof(remap_entry_t);
+    if (n_entries < REMAP_OLD_BTN_COUNT) return; /* need at least old-format count */
 
-    memcpy(g_profiles[profile], data, REMAP_BTN_COUNT * sizeof(remap_entry_t));
+    if (n_entries >= REMAP_BTN_COUNT) {
+        memcpy(g_profiles[profile], data, REMAP_BTN_COUNT * sizeof(remap_entry_t));
+    } else {
+        /* Partial (old web config sends 23 entries): copy what we have, identity-fill rest */
+        memcpy(g_profiles[profile], data, n_entries * sizeof(remap_entry_t));
+        for (size_t i = n_entries; i < REMAP_BTN_COUNT; i++)
+            g_profiles[profile][i] = (remap_entry_t){ REMAP_TYPE_BTN, (uint8_t)i, 0, 0 };
+    }
     for (int i = 0; i < REMAP_BTN_COUNT; i++)
         sanitize_entry(&g_profiles[profile][i], (uint8_t)i);
 
@@ -242,7 +364,21 @@ void remap_apply(uint8_t *p)
         p[5] = analog_l2;
     }
 
-    p[7] = (p[7] & 0x0F)
+    /* Reconstruct D-pad HAT from virtual direction bits */
+    uint8_t du = dst[REMAP_BTN_DPAD_UP],   dd = dst[REMAP_BTN_DPAD_DOWN];
+    uint8_t dl = dst[REMAP_BTN_DPAD_LEFT], dr = dst[REMAP_BTN_DPAD_RIGHT];
+    uint8_t hat;
+    if      (du && dr) hat = 1; /* NE */
+    else if (dr && dd) hat = 3; /* SE */
+    else if (dd && dl) hat = 5; /* SW */
+    else if (dl && du) hat = 7; /* NW */
+    else if (du)       hat = 0; /* N  */
+    else if (dr)       hat = 2; /* E  */
+    else if (dd)       hat = 4; /* S  */
+    else if (dl)       hat = 6; /* W  */
+    else               hat = 8; /* none */
+
+    p[7] = hat
          | (dst[REMAP_BTN_SQUARE]   ? 0x10 : 0)
          | (dst[REMAP_BTN_CROSS]    ? 0x20 : 0)
          | (dst[REMAP_BTN_CIRCLE]   ? 0x40 : 0)
@@ -303,6 +439,15 @@ void remap_on_disconnect(void)
         usb_gamepad_send_kbd_report(zero, 8);
     }
     memset(last_kbd_report, 0, sizeof(last_kbd_report));
+
+    /* Reset mouse state */
+    if (last_mouse_buttons && usb_gamepad_kbd_ready())
+        usb_gamepad_send_mouse_report(0, 0, 0, 0);
+    tp_mouse_last_x = -1;
+    tp_mouse_last_y = -1;
+    tp_click_held = false;
+    tp_right_triggered = false;
+    last_mouse_buttons = 0;
 }
 
 bool remap_has_kbd_targets(void)
@@ -312,4 +457,136 @@ bool remap_has_kbd_targets(void)
             if (g_profiles[p][i].type == REMAP_TYPE_KBD)
                 return true;
     return false;
+}
+
+bool remap_has_mouse_targets(void)
+{
+    for (int p = 0; p < REMAP_PROFILE_COUNT; p++)
+        for (int i = 0; i < REMAP_BTN_COUNT; i++)
+            if (g_profiles[p][i].type == REMAP_TYPE_MOUSE)
+                return true;
+    return false;
+}
+
+/* ------------------------------------------------------------------ */
+/* Touchpad mouse mode                                                  */
+/* ------------------------------------------------------------------ */
+
+#define TP_MOUSE_LONG_PRESS_MS  400
+
+static inline int8_t clamp8(int16_t v)
+{
+    if (v > 127) return 127;
+    if (v < -127) return -127;
+    return (int8_t)v;
+}
+
+void remap_mouse_tick(const uint8_t *p)
+{
+    uint8_t mode = config_get()->tp_mode;
+    /* Mouse only active in mode 2 (left mouse) or mode 3 (right mouse) */
+    if (mode != 2 && mode != 3) return;
+
+    const uint8_t *tp = &p[32];
+    bool finger_active = !(tp[0] & 0x80);
+    int16_t x = 0, y = 0;
+    if (finger_active) {
+        x = tp[1] | ((tp[2] & 0x0F) << 8);
+        y = ((tp[2] & 0xF0) >> 4) | (tp[3] << 4);
+    }
+
+    bool in_mouse_zone = false;
+    if (finger_active) {
+        if (mode == 2) in_mouse_zone = (x < TP_SPLIT_X);      /* left half */
+        else           in_mouse_zone = (x >= TP_SPLIT_X);     /* right half */
+    }
+
+    int8_t dx = 0, dy = 0;
+    uint8_t sensitivity = config_get()->tp_mouse_sensitivity;
+    if (sensitivity == 0) sensitivity = 8;
+
+    if (in_mouse_zone) {
+        if (tp_mouse_last_x < 0) {
+            tp_mouse_last_x = x;
+            tp_mouse_last_y = y;
+        } else {
+            int16_t raw_dx = x - tp_mouse_last_x;
+            int16_t raw_dy = y - tp_mouse_last_y;
+            dx = clamp8((raw_dx * (int16_t)sensitivity) / 16);
+            dy = clamp8((raw_dy * (int16_t)sensitivity) / 16);
+            tp_mouse_last_x = x;
+            tp_mouse_last_y = y;
+        }
+    } else {
+        tp_mouse_last_x = -1;
+        tp_mouse_last_y = -1;
+    }
+
+    /* Click handling: quick press = left, long press = right */
+    bool physical_click = (p[9] & 0x02) != 0;
+    uint8_t buttons = 0;
+    uint32_t now_ms = (uint32_t)(bflb_mtimer_get_time_us() / 1000);
+
+    if (physical_click && in_mouse_zone) {
+        if (!tp_click_held) {
+            tp_click_held = true;
+            tp_click_down_ms = now_ms;
+            tp_right_triggered = false;
+        }
+        if (!tp_right_triggered && (now_ms - tp_click_down_ms >= TP_MOUSE_LONG_PRESS_MS)) {
+            tp_right_triggered = true;
+        }
+        if (tp_right_triggered)
+            buttons |= 0x02; /* right button */
+    } else if (tp_click_held) {
+        /* Released */
+        if (tp_right_triggered) {
+            buttons = 0; /* release right */
+        } else {
+            /* Short press → left click (send press now, release next frame) */
+            buttons = 0x01;
+        }
+        tp_click_held = false;
+    }
+
+    /* Also handle REMAP_TYPE_MOUSE from other buttons */
+    const remap_entry_t *remap = g_profiles[active_profile];
+    for (int i = 0; i < REMAP_BTN_COUNT; i++) {
+        if (remap[i].type != REMAP_TYPE_MOUSE) continue;
+        if (!get_src_bit(p, i)) continue;
+        uint8_t btn_bit = 0;
+        if (remap[i].value == 0) btn_bit = 0x01;      /* left */
+        else if (remap[i].value == 1) btn_bit = 0x02;  /* right */
+        else if (remap[i].value == 2) btn_bit = 0x04;  /* middle */
+        buttons |= btn_bit;
+    }
+
+    if (dx != 0 || dy != 0 || buttons != last_mouse_buttons) {
+        if (usb_gamepad_kbd_ready())
+            usb_gamepad_send_mouse_report(buttons, dx, dy, 0);
+        last_mouse_buttons = buttons;
+    }
+}
+
+void remap_tp_cycle_mode(void)
+{
+    struct config_body *cfg = config_get();
+    uint8_t mask = cfg->tp_mode_enabled_mask & 0x1F;
+    if (mask == 0) mask = 0x01;
+
+    uint8_t cur = cfg->tp_mode;
+    for (int i = 0; i < 5; i++) {
+        cur = (cur + 1) % 5;
+        if (mask & (1u << cur)) break;
+    }
+    cfg->tp_mode = cur;
+
+    /* Reset mouse state on mode change */
+    tp_mouse_last_x = -1;
+    tp_mouse_last_y = -1;
+    tp_click_held = false;
+    tp_right_triggered = false;
+    if (last_mouse_buttons && usb_gamepad_kbd_ready())
+        usb_gamepad_send_mouse_report(0, 0, 0, 0);
+    last_mouse_buttons = 0;
 }

--- a/src/remap.h
+++ b/src/remap.h
@@ -8,7 +8,7 @@
 /* KBD: emit HID keyboard keycode (+ optional modifier or 2nd key)    */
 /* ------------------------------------------------------------------ */
 
-#define REMAP_BTN_COUNT  15
+#define REMAP_BTN_COUNT  31
 
 /* Source button IDs (index into g_remap[]) */
 #define REMAP_BTN_SQUARE    0
@@ -26,10 +26,32 @@
 #define REMAP_BTN_PS        12
 #define REMAP_BTN_TP_CLICK  13
 #define REMAP_BTN_MUTE      14
+#define REMAP_BTN_DPAD_UP   15
+#define REMAP_BTN_DPAD_DOWN 16
+#define REMAP_BTN_DPAD_LEFT 17
+#define REMAP_BTN_DPAD_RIGHT 18
+/* Touchpad left-half zone (X < 960) */
+#define REMAP_BTN_TP_L_TOUCH 19
+#define REMAP_BTN_TP_L_UP    20
+#define REMAP_BTN_TP_L_DOWN  21
+#define REMAP_BTN_TP_L_LEFT  22
+#define REMAP_BTN_TP_L_RIGHT 23
+#define REMAP_BTN_TP_L_CLICK 24
+/* Touchpad right-half zone (X >= 960) */
+#define REMAP_BTN_TP_R_TOUCH 25
+#define REMAP_BTN_TP_R_UP    26
+#define REMAP_BTN_TP_R_DOWN  27
+#define REMAP_BTN_TP_R_LEFT  28
+#define REMAP_BTN_TP_R_RIGHT 29
+#define REMAP_BTN_TP_R_CLICK 30
+
+#define REMAP_LEGACY_BTN_COUNT 15
+#define REMAP_OLD_BTN_COUNT    23  /* pre-split-zone table size */
 
 /* Target types */
-#define REMAP_TYPE_BTN 0   /* value = target button ID 0-14 */
-#define REMAP_TYPE_KBD 1   /* value = USB HID keycode       */
+#define REMAP_TYPE_BTN   0   /* value = target button ID 0-30 */
+#define REMAP_TYPE_KBD   1   /* value = USB HID keycode       */
+#define REMAP_TYPE_MOUSE 2   /* value = mouse button: 0=left, 1=right, 2=middle */
 
 /* flags bit 0 */
 #define REMAP_FLAG_SUPPRESS  0x01  /* suppress original gamepad bit output */
@@ -58,7 +80,10 @@ void remap_apply(uint8_t *payload);
 void remap_kbd_tick(const uint8_t *payload);
 void remap_on_disconnect(void);
 bool remap_has_kbd_targets(void);
+bool remap_has_mouse_targets(void);
+void remap_mouse_tick(const uint8_t *payload);
 const remap_entry_t *remap_get_table(void);
 const remap_entry_t *remap_get_profile_table(uint8_t profile);
 uint8_t remap_get_active_profile(void);
 void remap_switch_profile(uint8_t profile);
+void remap_tp_cycle_mode(void);

--- a/src/usb_gamepad.c
+++ b/src/usb_gamepad.c
@@ -23,9 +23,9 @@
 
 #if defined(BOARD_LCTECH_616)
   #ifdef FORCE_FS_MODE
-    #define FIRMWARE_VERSION "LCT616-DS5 3.17"
+    #define FIRMWARE_VERSION "LCT616-DS5 3.18"
   #else
-    #define FIRMWARE_VERSION "LCT616-DS5 3.17H"
+    #define FIRMWARE_VERSION "LCT616-DS5 3.18H"
   #endif
 #elif defined(BOARD_M0S_DOCK)
 #define FIRMWARE_VERSION "M0S-DS5 3.5"
@@ -43,7 +43,7 @@
 #define USB_HID_CONFIG_SIZE (9 + USB_AUDIO_DESC_SIZE + USB_HID_ONLY_SIZE)
 #define HID_REPORT_DESC_SIZE_DS  329
 #define HID_REPORT_DESC_SIZE_DSE 445
-#define KBD_REPORT_DESC_SIZE 80
+#define KBD_REPORT_DESC_SIZE 138  /* Keyboard + Consumer + Mouse */
 
 static bool current_dse_mode = false;
 
@@ -237,7 +237,7 @@ static const uint8_t hid_report_desc_ds[HID_REPORT_DESC_SIZE_DS] = {
     0xB1, 0x02,
     0x85, 0xFB,       /*   Report ID (251) — button remap table */
     0x09, 0x3C,
-    0x95, 0x3F,
+    0x95, 0x7F,       /*   Report Count (127) — 31 entries * 4 + header */
     0xB1, 0x02,
 
     0xC0,             /* End Collection */
@@ -312,11 +312,11 @@ static const uint8_t hid_report_desc_dse[HID_REPORT_DESC_SIZE_DSE] = {
     0x85, 0xF7, 0x09, 0x38, 0x95, 0x3F, 0xB1, 0x02,
     0x85, 0xF8, 0x09, 0x39, 0x95, 0x3F, 0xB1, 0x02,
     0x85, 0xF9, 0x09, 0x3A, 0x95, 0x3F, 0xB1, 0x02,
-    0x85, 0xFB, 0x09, 0x3C, 0x95, 0x3F, 0xB1, 0x02,  /* button remap table */
+    0x85, 0xFB, 0x09, 0x3C, 0x95, 0x7F, 0xB1, 0x02,  /* button remap table (127B) */
     0xC0,
 };
 
-/* Multi-TLC HID report descriptor: Keyboard (Report ID 1) + Consumer Control (Report ID 2) */
+/* Multi-TLC HID report descriptor: Keyboard (Report ID 1) + Consumer Control (Report ID 2) + Mouse (Report ID 3) */
 static const uint8_t kbd_report_desc[KBD_REPORT_DESC_SIZE] = {
     /* ── Collection 1: Keyboard (Report ID 1, 9 bytes total) ── */
     0x05, 0x01,       /* Usage Page (Generic Desktop) */
@@ -361,6 +361,38 @@ static const uint8_t kbd_report_desc[KBD_REPORT_DESC_SIZE] = {
     0x75, 0x05,       /*   Report Size (5) — padding */
     0x81, 0x01,       /*   Input (Const) */
     0xC0,             /* End Collection */
+
+    /* ── Collection 3: Mouse (Report ID 3, 4 bytes: btns + X + Y + wheel) ── */
+    0x05, 0x01,       /* Usage Page (Generic Desktop) */
+    0x09, 0x02,       /* Usage (Mouse) */
+    0xA1, 0x01,       /* Collection (Application) */
+    0x85, 0x03,       /*   Report ID (3) */
+    0x09, 0x01,       /*   Usage (Pointer) */
+    0xA1, 0x00,       /*   Collection (Physical) */
+    0x05, 0x09,       /*   Usage Page (Button) */
+    0x19, 0x01,       /*   Usage Minimum (1) */
+    0x29, 0x03,       /*   Usage Maximum (3) */
+    0x15, 0x00,       /*   Logical Minimum (0) */
+    0x25, 0x01,       /*   Logical Maximum (1) */
+    0x95, 0x03,       /*   Report Count (3) */
+    0x75, 0x01,       /*   Report Size (1) */
+    0x81, 0x02,       /*   Input (Data,Var,Abs) — 3 buttons */
+    0x95, 0x01,       /*   Report Count (1) */
+    0x75, 0x05,       /*   Report Size (5) */
+    0x81, 0x01,       /*   Input (Const) — padding */
+    0x05, 0x01,       /*   Usage Page (Generic Desktop) */
+    0x09, 0x30,       /*   Usage (X) */
+    0x09, 0x31,       /*   Usage (Y) */
+    0x15, 0x81,       /*   Logical Minimum (-127) */
+    0x25, 0x7F,       /*   Logical Maximum (127) */
+    0x75, 0x08,       /*   Report Size (8) */
+    0x95, 0x02,       /*   Report Count (2) */
+    0x81, 0x06,       /*   Input (Data,Var,Rel) — X, Y */
+    0x09, 0x38,       /*   Usage (Wheel) */
+    0x95, 0x01,       /*   Report Count (1) */
+    0x81, 0x06,       /*   Input (Data,Var,Rel) — Wheel */
+    0xC0,             /*   End Collection (Physical) */
+    0xC0,             /* End Collection (Application) */
 };
 
 static uint8_t device_desc[] = {
@@ -540,6 +572,27 @@ static const char *desc_string_cb(uint8_t speed, uint8_t index)
     default: return NULL;
     }
 }
+
+/* BOS descriptor: declare USB 2.0 Extension with LPM NOT supported.
+ * Prevents Linux from attempting L1 power-state transitions. */
+static const uint8_t bos_desc_raw[] = {
+    /* BOS Header */
+    0x05,                   /* bLength */
+    0x0F,                   /* bDescriptorType: BOS */
+    0x0C, 0x00,             /* wTotalLength: 12 */
+    0x01,                   /* bNumDeviceCaps: 1 */
+
+    /* USB 2.0 Extension Device Capability */
+    0x07,                   /* bLength */
+    0x10,                   /* bDescriptorType: DEVICE_CAPABILITY */
+    0x02,                   /* bDevCapabilityType: USB 2.0 Extension */
+    0x00, 0x00, 0x00, 0x00, /* bmAttributes: bit1=0 → LPM not supported */
+};
+
+static const struct usb_bos_descriptor bos_desc = {
+    .string     = bos_desc_raw,
+    .string_len = sizeof(bos_desc_raw),
+};
 
 static const struct usb_descriptor usb_desc = {
     .device_descriptor_callback          = desc_device_cb,
@@ -753,7 +806,8 @@ int usb_gamepad_init(usb_gamepad_output_cb_t output_cb)
      * no keyboard interface needed. remap KBD type is disabled for now.
      * REMOTE-WAKEUP bit stays in bmAttributes when wake is enabled. */
     const bool need_kbd = remap_has_kbd_targets() ||
-                          config_get()->ps_shortcut_enabled;
+                          config_get()->ps_shortcut_enabled ||
+                          (config_get()->tp_mode == 2 || config_get()->tp_mode == 3);
     const bool need_remote_wake = config_get()->enable_wake || need_kbd;
     if (need_kbd) {
         config_desc[KBD_SUBCLASS_OFF] = 0x00; /* No subclass (multi-TLC, not pure boot) */
@@ -837,6 +891,8 @@ int usb_gamepad_init(usb_gamepad_output_cb_t output_cb)
         volatile uint32_t *dev_ctl = (volatile uint32_t *)(USB_BASE + 0x100);
         uint32_t v = *dev_ctl;
         v |= (1 << 2);  /* USB_GLINT_EN_HOV */
+        v &= ~(1 << 25); /* Clear USB_LPM_EN — refuse L1 power state */
+        v &= ~(1 << 26); /* Clear USB_LPM_ACCEPT — NYET all LPM requests */
         *dev_ctl = v;
     }
 
@@ -945,6 +1001,23 @@ int usb_gamepad_send_consumer_report(uint16_t bits)
     kbd_ep_busy = true;
     kbd_ep_busy_since_us = bflb_mtimer_get_time_us();
     int ret = usbd_ep_start_write(0, USB_KBD_EP_IN, kbd_buf, 2);
+    if (ret < 0)
+        kbd_ep_busy = false;
+    return ret;
+}
+
+int usb_gamepad_send_mouse_report(uint8_t buttons, int8_t dx, int8_t dy, int8_t wheel)
+{
+    if (!usb_configured || !kbd_registered || kbd_ep_busy)
+        return -1;
+    kbd_buf[0] = 0x03; /* Report ID 3 = Mouse */
+    kbd_buf[1] = buttons;
+    kbd_buf[2] = (uint8_t)dx;
+    kbd_buf[3] = (uint8_t)dy;
+    kbd_buf[4] = (uint8_t)wheel;
+    kbd_ep_busy = true;
+    kbd_ep_busy_since_us = bflb_mtimer_get_time_us();
+    int ret = usbd_ep_start_write(0, USB_KBD_EP_IN, kbd_buf, 5);
     if (ret < 0)
         kbd_ep_busy = false;
     return ret;
@@ -1102,10 +1175,22 @@ void usbd_hid_get_report(uint8_t busid, uint8_t intf, uint8_t report_id,
             if (state_mgr_is_spk_active())        aflags |= 0x02;
             if (usb_audio_mic_is_active())         aflags |= 0x01;
             feature_resp_buf[2] = aflags;
-            feature_resp_buf[3] = get_battery_level();
-            feature_resp_buf[4] = get_battery_state();
+            /* Layout kept identical to the private firmware so the companion
+             * web tool can parse RSSI / audio / battery. OTA fields are
+             * reserved and always zero — this build has no OTA. */
+            feature_resp_buf[3]  = 0;   /* OTA status (idle) */
+            feature_resp_buf[4]  = 0;   /* OTA bytes received */
+            feature_resp_buf[5]  = 0;
+            feature_resp_buf[6]  = 0;
+            feature_resp_buf[7]  = 0;
+            feature_resp_buf[8]  = 0;   /* OTA total size */
+            feature_resp_buf[9]  = 0;
+            feature_resp_buf[10] = 0;
+            feature_resp_buf[11] = 0;
+            feature_resp_buf[12] = get_battery_level();
+            feature_resp_buf[13] = get_battery_state();
             *data = feature_resp_buf;
-            *len  = 5;
+            *len  = 14;
         } else if (report_id == 0xFB) {
             feature_resp_buf[0] = 0xFB;
             feature_resp_buf[1] = remap_get_active_profile();
@@ -1194,14 +1279,14 @@ void usbd_hid_set_report(uint8_t busid, uint8_t intf, uint8_t report_id,
         uint8_t cmd = payload[0];
         if (cmd == 0x01) {
             /* 0x01 [profile] [data...] — set remap for profile */
-            if (payload_len >= 2 + REMAP_BTN_COUNT * sizeof(remap_entry_t)) {
+            if (payload_len >= 2 + REMAP_OLD_BTN_COUNT * (int)sizeof(remap_entry_t)) {
                 uint8_t prof = payload[1];
                 if (prof >= REMAP_PROFILE_COUNT) prof = 0;
                 remap_set_profile(prof, payload + 2, (uint8_t)(payload_len - 2));
                 usb_remap_save_profile = prof;
                 usb_remap_save_pending = true;
-                LOG_INF("[USB] CMD 0xFB/0x01: profile %d updated\n", prof);
-            } else if (payload_len >= 1 + REMAP_BTN_COUNT * sizeof(remap_entry_t)) {
+                LOG_INF("[USB] CMD 0xFB/0x01: profile %d updated (%d bytes)\n", prof, payload_len - 2);
+            } else if (payload_len >= 1 + REMAP_OLD_BTN_COUNT * (int)sizeof(remap_entry_t)) {
                 /* backward compat: no profile byte → profile 0 */
                 remap_set_profile(0, payload + 1, (uint8_t)(payload_len - 1));
                 usb_remap_save_profile = 0;

--- a/src/usb_gamepad.h
+++ b/src/usb_gamepad.h
@@ -31,6 +31,7 @@ int usb_gamepad_send_raw_input(const uint8_t *payload);
 bool usb_gamepad_is_ready(void);
 int  usb_gamepad_send_kbd_report(const uint8_t *report, uint8_t len);
 int  usb_gamepad_send_consumer_report(uint16_t usage);
+int  usb_gamepad_send_mouse_report(uint8_t buttons, int8_t dx, int8_t dy, int8_t wheel);
 bool usb_gamepad_kbd_ready(void);
 
 void usb_gamepad_set_suspend_hooks(void (*on_suspend)(void),


### PR DESCRIPTION
Sync v3.18 from the private repo (closed-source wins on conflicts), OTA/key content excluded.

Highlights:
- E907 DSP audio encode/decode optimization, task priority/timing tuning
- Polling rate 500Hz+ when speaker + microphone active
- New controller test panel, multi-mode touchpad mapping, audio haptics, D-pad/touchpad direction mapping
- Stability fixes (reconnect LED color, long-audio cutout, Linux USB LPM, fault tolerance)
- Fix: restore 0xF9 status report to the 14-byte layout so the web config tool shows controller connected / battery correctly (open-source build has no OTA; reserved OTA bytes are zero)